### PR TITLE
Add segment delegate

### DIFF
--- a/Source/DZNSegmentedControl.h
+++ b/Source/DZNSegmentedControl.h
@@ -11,6 +11,7 @@
 #import <UIKit/UIKit.h>
 
 @protocol DZNSegmentedControlDelegate;
+@protocol DZNSegmentedControlSegmentDelegate;
 
 /**
  A drop-in replacement for UISegmentedControl showing multiple segment counts, to be used typically on a user profile.
@@ -19,6 +20,7 @@
 
 /** The control's delegate object, conforming to the UIBarPositioning protocol. */
 @property (nonatomic, weak) id <DZNSegmentedControlDelegate> delegate;
+@property (nonatomic, weak) id <DZNSegmentedControlSegmentDelegate> segmentDelegate;
 /** The items displayed on the control. */
 @property (nonatomic, retain) NSArray *items;
 /** The index number identifying the selected segment (that is, the last segment touched). */
@@ -134,4 +136,10 @@
  The DZNSegmentedControlDelegate protocol defines the interface that DZNSegmentedControl delegate objects implement to manage the segmented control behavior. This protocol declares no methods of its own but conforms to the UIBarPositioningDelegate protocol to support the positioning of a segmented control when it is moved to a window.
  */
 @protocol DZNSegmentedControlDelegate <UIBarPositioningDelegate>
+@end
+
+@protocol DZNSegmentedControlSegmentDelegate
+
+- (void)segmentedControl:(DZNSegmentedControl *)segmentedControl didHaveSegmentTouchedUpInside:(NSUInteger)segment wasNewSelection:(BOOL)newSelection;
+
 @end

--- a/Source/DZNSegmentedControl.h
+++ b/Source/DZNSegmentedControl.h
@@ -11,7 +11,6 @@
 #import <UIKit/UIKit.h>
 
 @protocol DZNSegmentedControlDelegate;
-@protocol DZNSegmentedControlSegmentDelegate;
 
 /**
  A drop-in replacement for UISegmentedControl showing multiple segment counts, to be used typically on a user profile.
@@ -20,7 +19,6 @@
 
 /** The control's delegate object, conforming to the UIBarPositioning protocol. */
 @property (nonatomic, weak) id <DZNSegmentedControlDelegate> delegate;
-@property (nonatomic, weak) id <DZNSegmentedControlSegmentDelegate> segmentDelegate;
 /** The items displayed on the control. */
 @property (nonatomic, retain) NSArray *items;
 /** The index number identifying the selected segment (that is, the last segment touched). */
@@ -136,9 +134,8 @@
  The DZNSegmentedControlDelegate protocol defines the interface that DZNSegmentedControl delegate objects implement to manage the segmented control behavior. This protocol declares no methods of its own but conforms to the UIBarPositioningDelegate protocol to support the positioning of a segmented control when it is moved to a window.
  */
 @protocol DZNSegmentedControlDelegate <UIBarPositioningDelegate>
-@end
 
-@protocol DZNSegmentedControlSegmentDelegate
+@optional
 
 - (void)segmentedControl:(DZNSegmentedControl *)segmentedControl didHaveSegmentTouchedUpInside:(NSUInteger)segment wasNewSelection:(BOOL)newSelection;
 

--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -410,7 +410,9 @@ static const CGFloat kBadgeMargin = 3.f;
 - (void)setDelegate:(id<DZNSegmentedControlDelegate>)delegate
 {
     _delegate = delegate;
-    _barPosition = [delegate positionForBar:self];
+    if ([delegate respondsToSelector:@selector(positionForBar:)]) {
+        _barPosition = [delegate positionForBar:self];
+    }
 }
 
 - (void)setSelectedSegmentIndex:(NSInteger)segment
@@ -795,7 +797,9 @@ static const CGFloat kBadgeMargin = 3.f;
 }
 
 - (void)buttonTouchedUpInside:(UIButton *)sender {
-    [self.segmentDelegate segmentedControl:self didHaveSegmentTouchedUpInside:sender.tag wasNewSelection:self.wasNewSelection];
+    if ([self.delegate respondsToSelector:@selector(segmentedControl:didHaveSegmentTouchedUpInside:wasNewSelection:)]) {
+        [self.delegate segmentedControl:self didHaveSegmentTouchedUpInside:sender.tag wasNewSelection:self.wasNewSelection];
+    }
 }
 
 - (void)disableAllButtonsSelection

--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -21,6 +21,7 @@ static const CGFloat kBadgeMargin = 3.f;
 @property (nonatomic, strong) NSMutableArray *counts; // of NSNumber
 @property (nonatomic, getter = isTransitioning) BOOL transitioning;
 @property (nonatomic, strong) DZNBadge *badge;
+@property (nonatomic) BOOL wasNewSelection;
 
 @end
 
@@ -58,6 +59,7 @@ static const CGFloat kBadgeMargin = 3.f;
     [self bringSubviewToFront:_badge];
 
     _initializing = NO;
+    _wasNewSelection = NO;
 }
 
 - (id)init
@@ -718,6 +720,7 @@ static const CGFloat kBadgeMargin = 3.f;
 {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
 
+    [button addTarget:self action:@selector(buttonTouchedUpInside:) forControlEvents:UIControlEventTouchUpInside];
     [button addTarget:self action:@selector(willSelectedButton:) forControlEvents:UIControlEventTouchDown];
     [button addTarget:self action:@selector(didSelectButton:) forControlEvents:UIControlEventTouchDragOutside|UIControlEventTouchDragInside|UIControlEventTouchDragEnter|UIControlEventTouchDragExit|UIControlEventTouchCancel|UIControlEventTouchUpInside|UIControlEventTouchUpOutside];
 
@@ -781,6 +784,8 @@ static const CGFloat kBadgeMargin = 3.f;
 - (void)willSelectedButton:(id)sender
 {
     UIButton *button = (UIButton *)sender;
+    
+    self.wasNewSelection = button.tag != self.selectedSegmentIndex;
 
     if (!self.isTransitioning) {
         self.selectedSegmentIndex = button.tag;
@@ -793,6 +798,10 @@ static const CGFloat kBadgeMargin = 3.f;
 
     button.highlighted = NO;
     button.selected = YES;
+}
+
+- (void)buttonTouchedUpInside:(UIButton *)sender {
+    [self.segmentDelegate segmentedControl:self didHaveSegmentTouchedUpInside:sender.tag wasNewSelection:self.wasNewSelection];
 }
 
 - (void)disableAllButtonsSelection

--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -602,14 +602,11 @@ static const CGFloat kBadgeMargin = 3.f;
     }
 
     [self disableAllButtonsSelection];
-    [self enableAllButtonsInteraction:NO];
 
     CGFloat duration = (self.selectedSegmentIndex < 0.0f) ? 0.0f : self.animationDuration;
 
     _selectedSegmentIndex = segment;
     _transitioning = YES;
-
-    UIButton *button = [self buttonAtIndex:segment];
 
     CGFloat damping = !self.bouncySelectionIndicator ? : 0.65f;
     CGFloat velocity = !self.bouncySelectionIndicator ? : 0.5f;
@@ -623,8 +620,6 @@ static const CGFloat kBadgeMargin = 3.f;
                          self.selectionIndicator.frame = [self selectionIndicatorRect];
                      }
                      completion:^(BOOL finished) {
-                         [self enableAllButtonsInteraction:YES];
-                         button.userInteractionEnabled = NO;
                          _transitioning = NO;
                      }];
 
@@ -809,13 +804,6 @@ static const CGFloat kBadgeMargin = 3.f;
     for (UIButton *button in [self buttons]) {
         button.highlighted = NO;
         button.selected = NO;
-    }
-}
-
-- (void)enableAllButtonsInteraction:(BOOL)enable
-{
-    for (UIButton *button in [self buttons]) {
-        button.userInteractionEnabled = enable;
     }
 }
 

--- a/Source/DZNSegmentedControl.m
+++ b/Source/DZNSegmentedControl.m
@@ -779,10 +779,9 @@ static const CGFloat kBadgeMargin = 3.f;
 - (void)willSelectedButton:(id)sender
 {
     UIButton *button = (UIButton *)sender;
-    
-    self.wasNewSelection = button.tag != self.selectedSegmentIndex;
 
     if (!self.isTransitioning) {
+        self.wasNewSelection = button.tag != self.selectedSegmentIndex;
         self.selectedSegmentIndex = button.tag;
     }
 }


### PR DESCRIPTION
This allows for actions on a `UIControlEventTouchUpInside` for a segment, while knowing if the segment was the current selection or a new one (there's some new state management accounting for this since the selection changes on a `UIControlEventTouchDown`)